### PR TITLE
Change CloudInit to allow for root login over ssh

### DIFF
--- a/provisioning/templates/cloud-config.yml
+++ b/provisioning/templates/cloud-config.yml
@@ -16,4 +16,8 @@ runcmd:
   - ip link set dev enp1s0 up
   - netplan apply
 {% endif %}
-  - sleep 60 ; for i in {1..5}; do wget -O - https://console.aarch64.com/api/intra/phonehome ; done
+  - sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+{% if item.os == "ubuntu" or item.os == "debian" %}
+  - systemctl restart sshd
+{% endif %}
+  - sleep 60 ; for i in {1..5}; do wget -O - https://console.aarch64.com/api/intra/phonehome ; done 


### PR DESCRIPTION
This allows for root login over ssh so that users do not have to use the console to then enable root login themselves